### PR TITLE
Fix: JSON deserialiser

### DIFF
--- a/deserialization/json.go
+++ b/deserialization/json.go
@@ -1,7 +1,16 @@
 package deserialization
 
-import "encoding/json"
+import (
+	"fmt"
+
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+)
 
 func DeserializeJSON(b []byte, i interface{}) error {
-	return json.Unmarshal(b, i)
+	message, ok := i.(proto.Message)
+	if !ok {
+		return fmt.Errorf("expected a valid json which could be decoded into a protobuf")
+	}
+	return protojson.Unmarshal(b, message)
 }

--- a/deserialization/json_test.go
+++ b/deserialization/json_test.go
@@ -1,6 +1,7 @@
 package deserialization
 
 import "testing"
+import pb "github.com/raystack/raccoon/proto"
 
 func TestJSONDeserializer_Deserialize(t *testing.T) {
 	type args struct {
@@ -17,10 +18,17 @@ func TestJSONDeserializer_Deserialize(t *testing.T) {
 			name: "Use JSON Deserializer",
 			j:    DeserializeJSON,
 			args: args{
-				b: []byte(`{"A": "a"}`),
-				i: &struct {
-					A string
-				}{},
+				b: []byte(`{
+					"reqGuid": "17e2ac19-df8b-4a30-b111-fd7f5073d2f5",
+					"sentTime": "2023-08-17T05:38:49.234986Z",
+					"events": [
+					  {
+						"eventBytes": "eyJyYW5kb20xIjogImFiYyIsICJ4eXoiOiAxfQ==",
+						"type": "topic 1"
+					  }
+					]
+				  }`),
+				i: &pb.SendEventRequest{},
 			},
 			wantErr: false,
 		},


### PR DESCRIPTION
Bug: json message isn't correctly serialised, even when published in protobuf compliant JSON format.

Context:
1. Protobuf style guide states that JSON keys should be in camelCase, and protobuf keys/field names should be in snake_case.
2. Thus, when a Request Payload is serialised. It uses CamelCase. 
3. However, since raccoon uses standard encoding/json package to deserialise, it does not correctly deserialise camelCase keys of Json.

Fix:
1. Start using protobuf's official encoding/protojson package for deserialisation.
2. It adhere's to the style guide of protobuf, which supports deserialisation of both snake_case and camelCase keys in JSON.
