### PR TITLE
fix: panic for unknown topic metric

### DIFF
--- a/metrics/prometheus.go
+++ b/metrics/prometheus.go
@@ -152,7 +152,7 @@ func getCounterMap() map[string]CounterVec {
 		Help: "Number of events received in requests"}, []string{"conn_group", "event_type"})
 	counters["kafka_unknown_topic_failure_total"] = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "kafka_unknown_topic_failure_total",
-		Help: "Number of delivery failure caused by topic does not exist in kafka."}, []string{"topic", "event_type"})
+		Help: "Number of delivery failure caused by topic does not exist in kafka."}, []string{"topic", "event_type", "conn_group"})
 	counters["batches_read_total"] = prometheus.NewCounterVec(prometheus.CounterOpts{
 		Name: "batches_read_total",
 		Help: "Request count"}, []string{"status", "reason", "conn_group"})

--- a/metrics/prometheus_test.go
+++ b/metrics/prometheus_test.go
@@ -168,8 +168,8 @@ func (promSuite *PrometheusTestSuite) Test_Prometheus_Counter_Working() {
 	mockCounter1 := mockCounter{}
 	mockCounter2 := mockCounter{}
 	callArg1 := int64(35)
-	labels1 := map[string]string{"topic": "test", "event_type": "abc"}
-	promLabels1 := prometheus.Labels{"topic": "test", "event_type": "abc"}
+	labels1 := map[string]string{"topic": "test", "event_type": "abc", "conn_group": "--default--"}
+	promLabels1 := prometheus.Labels{"topic": "test", "event_type": "abc", "conn_group": "--default--"}
 	labels2 := map[string]string{"status": "success", "reason": "unknown", "conn_group": "abc"}
 	promLabels2 := prometheus.Labels{"status": "success", "reason": "unknown", "conn_group": "abc"}
 	var err error


### PR DESCRIPTION
This PR fixes panic when multiple requests are made for a topic which does not exist
```
ERRO[2024-04-09T16:39:44+05:30] [worker] Fail to publish message to kafka Broker: Unknown topic or partition 
DEBU[2024-04-09T16:39:44+05:30] Success sending messages, 0                  
panic: inconsistent label cardinality: expected 2 label values but got 3 in prometheus.Labels{"conn_group":"--default--", "event_type":"abc", "topic":"log.telemetry.abc"}

goroutine 43 [running]:
github.com/prometheus/client_golang/prometheus.(*CounterVec).With(0x100ff6a00?, 0x1400020ce70?)
        /Users/rapido/go/pkg/mod/github.com/prometheus/client_golang@v1.16.0/prometheus/counter.go:286 +0x80
github.com/raystack/raccoon/metrics.(*PrometheusCollector).Increment(0x110?, {0x100d9f85c, 0x21}, 0x101086ee0?)
        /Users/rapido/work/raccoon-2/metrics/prometheus.go:77 +0x64
github.com/raystack/raccoon/metrics.Increment({0x100d9f85c?, 0x140000f2450?}, 0x100d8d0ff?)
        /Users/rapido/work/raccoon-2/metrics/metrics.go:45 +0x4c
github.com/raystack/raccoon/publisher.(*Kafka).ProduceBulk(0x14000286000, {0x1400029a140, 0x1, 0x6?}, {0x100d8d61a, 0xb}, 0x1?)
        /Users/rapido/work/raccoon-2/publisher/kafka.go:66 +0x518
github.com/raystack/raccoon/worker.(*Pool).StartWorkers.func1({0x14000204090, 0x8})
        /Users/rapido/work/raccoon-2/worker/worker.go:47 +0x214
created by github.com/raystack/raccoon/worker.(*Pool).StartWorkers
        /Users/rapido/work/raccoon-2/worker/worker.go:39 +0x3c
exit status 2
```